### PR TITLE
Import & Export accessories, Showing Mail plug-in availability

### DIFF
--- a/OpenHaystack/OpenHaystack/FindMy/FindMyController.swift
+++ b/OpenHaystack/OpenHaystack/FindMy/FindMyController.swift
@@ -15,7 +15,6 @@ import SwiftUI
 class FindMyController: ObservableObject {
     @Published var error: Error?
     @Published var devices = [FindMyDevice]()
-    @Environment(\.accessoryController) var accessories: AccessoryController
 
     func loadPrivateKeys(from data: Data, with searchPartyToken: Data, completion: @escaping (Error?) -> Void) {
         do {
@@ -97,11 +96,6 @@ class FindMyController: ObservableObject {
         self.devices = findMyDevices
 
         self.fetchReports(with: token) { error in
-
-            let reports = self.devices.compactMap({ $0.reports }).flatMap({ $0 })
-            if reports.isEmpty == false {
-                self.accessories.updateWithDecryptedReports(devices: self.devices)
-            }
 
             if let error = error {
                 completion(.failure(error))

--- a/OpenHaystack/OpenHaystack/FindMy/FindMyController.swift
+++ b/OpenHaystack/OpenHaystack/FindMy/FindMyController.swift
@@ -15,11 +15,7 @@ import SwiftUI
 class FindMyController: ObservableObject {
     @Published var error: Error?
     @Published var devices = [FindMyDevice]()
-    var accessories: AccessoryController
-
-    init(accessories: AccessoryController) {
-        self.accessories = accessories
-    }
+    @Environment(\.accessoryController) var accessories: AccessoryController
 
     func loadPrivateKeys(from data: Data, with searchPartyToken: Data, completion: @escaping (Error?) -> Void) {
         do {

--- a/OpenHaystack/OpenHaystack/HaystackApp/Views/ManageAccessoriesView.swift
+++ b/OpenHaystack/OpenHaystack/HaystackApp/Views/ManageAccessoriesView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct ManageAccessoriesView: View {
 
-    @Environment(\.accessoryController) var accessoryController: AccessoryController
+    @EnvironmentObject var accessoryController: AccessoryController
     var accessories: [Accessory] {
         return self.accessoryController.accessories
     }
@@ -21,6 +21,9 @@ struct ManageAccessoriesView: View {
     @Binding var focusedAccessory: Accessory?
     @Binding var accessoryToDeploy: Accessory?
     @Binding var showESP32DeploySheet: Bool
+    var mailPluginIsActive: Bool
+    
+    @State var showMailPopup = false
 
     var body: some View {
         VStack {
@@ -40,17 +43,29 @@ struct ManageAccessoriesView: View {
         .toolbar(content: {
             Spacer()
             
-            Button(action: self.importAccessories, label: {
-                Label("Export accessories", systemImage: "square.and.arrow.down")
+            Button(action: {self.showMailPopup.toggle()}, label: {
+                Label("Plugin state", systemImage: "envelope")
+                    .foregroundColor(self.mailPluginIsActive ? nil : .red)
             })
+            .help(self.mailPluginIsActive ? "Mail plug-in is active" : "Cannot connect to Mail plug-in")
+            .popover(isPresented: self.$showMailPopup) {
+                self.mailStatePopup
+            }
+            
+            Button(action: self.importAccessories, label: {
+                Label("Import accessories", systemImage: "square.and.arrow.down")
+            })
+            .help("Import accessories from a file")
             
             Button(action: self.exportAccessories, label: {
                 Label("Export accessories", systemImage: "square.and.arrow.up")
             })
+            .help("Export all accessories to a file")
             
             Button(action: self.addAccessory) {
                 Label("Add accessory", systemImage: "plus")
             }
+            .help("Add a new accessory")
         })
         .sheet(
             isPresented: self.$showESP32DeploySheet,
@@ -83,6 +98,23 @@ struct ManageAccessoriesView: View {
         }
         .listStyle(SidebarListStyle())
 
+    }
+    
+    var mailStatePopup: some View {
+        HStack {
+            Image(systemName: "envelope")
+                .foregroundColor(self.mailPluginIsActive ? .green : .red)
+            
+            if self.mailPluginIsActive {
+                Text("The mail plug-in is up and running")
+            }else {
+                Text("Cannot connect to the mail plug-in. Open Apple Mail and make sure the plug-in is enabled")
+                    .lineLimit(10)
+                    .multilineTextAlignment(.leading)
+            }
+        }
+        .frame(maxWidth: 250)
+        .padding()
     }
 
     /// Delete an accessory from the list of accessories.
@@ -135,6 +167,6 @@ struct ManageAccessoriesView_Previews: PreviewProvider {
     @State static var showESPSheet: Bool = true
 
     static var previews: some View {
-        ManageAccessoriesView(alertType: self.$alertType, focusedAccessory: self.$focussed, accessoryToDeploy: self.$deploy, showESP32DeploySheet: self.$showESPSheet)
+        ManageAccessoriesView(alertType: self.$alertType, focusedAccessory: self.$focussed, accessoryToDeploy: self.$deploy, showESP32DeploySheet: self.$showESPSheet, mailPluginIsActive: true)
     }
 }

--- a/OpenHaystack/OpenHaystack/HaystackApp/Views/ManageAccessoriesView.swift
+++ b/OpenHaystack/OpenHaystack/HaystackApp/Views/ManageAccessoriesView.swift
@@ -21,7 +21,6 @@ struct ManageAccessoriesView: View {
     @Binding var focusedAccessory: Accessory?
     @Binding var accessoryToDeploy: Accessory?
     @Binding var showESP32DeploySheet: Bool
-    var mailPluginIsActive: Bool
     
     @State var showMailPopup = false
 
@@ -41,31 +40,7 @@ struct ManageAccessoriesView: View {
             }
         }
         .toolbar(content: {
-            Spacer()
-            
-            Button(action: {self.showMailPopup.toggle()}, label: {
-                Label("Plugin state", systemImage: "envelope")
-                    .foregroundColor(self.mailPluginIsActive ? nil : .red)
-            })
-            .help(self.mailPluginIsActive ? "Mail plug-in is active" : "Cannot connect to Mail plug-in")
-            .popover(isPresented: self.$showMailPopup) {
-                self.mailStatePopup
-            }
-            
-            Button(action: self.importAccessories, label: {
-                Label("Import accessories", systemImage: "square.and.arrow.down")
-            })
-            .help("Import accessories from a file")
-            
-            Button(action: self.exportAccessories, label: {
-                Label("Export accessories", systemImage: "square.and.arrow.up")
-            })
-            .help("Export all accessories to a file")
-            
-            Button(action: self.addAccessory) {
-                Label("Add accessory", systemImage: "plus")
-            }
-            .help("Add a new accessory")
+            self.toolbarView
         })
         .sheet(
             isPresented: self.$showESP32DeploySheet,
@@ -100,21 +75,27 @@ struct ManageAccessoriesView: View {
 
     }
     
-    var mailStatePopup: some View {
-        HStack {
-            Image(systemName: "envelope")
-                .foregroundColor(self.mailPluginIsActive ? .green : .red)
+    
+    /// All toolbar buttons shown 
+    var toolbarView: some View {
+        Group {
+            Spacer()
             
-            if self.mailPluginIsActive {
-                Text("The mail plug-in is up and running")
-            }else {
-                Text("Cannot connect to the mail plug-in. Open Apple Mail and make sure the plug-in is enabled")
-                    .lineLimit(10)
-                    .multilineTextAlignment(.leading)
+            Button(action: self.importAccessories, label: {
+                Label("Import accessories", systemImage: "square.and.arrow.down")
+            })
+            .help("Import accessories from a file")
+            
+            Button(action: self.exportAccessories, label: {
+                Label("Export accessories", systemImage: "square.and.arrow.up")
+            })
+            .help("Export all accessories to a file")
+            
+            Button(action: self.addAccessory) {
+                Label("Add accessory", systemImage: "plus")
             }
+            .help("Add a new accessory")
         }
-        .frame(maxWidth: 250)
-        .padding()
     }
 
     /// Delete an accessory from the list of accessories.
@@ -167,6 +148,6 @@ struct ManageAccessoriesView_Previews: PreviewProvider {
     @State static var showESPSheet: Bool = true
 
     static var previews: some View {
-        ManageAccessoriesView(alertType: self.$alertType, focusedAccessory: self.$focussed, accessoryToDeploy: self.$deploy, showESP32DeploySheet: self.$showESPSheet, mailPluginIsActive: true)
+        ManageAccessoriesView(alertType: self.$alertType, focusedAccessory: self.$focussed, accessoryToDeploy: self.$deploy, showESP32DeploySheet: self.$showESPSheet)
     }
 }

--- a/OpenHaystack/OpenHaystack/HaystackApp/Views/ManageAccessoriesView.swift
+++ b/OpenHaystack/OpenHaystack/HaystackApp/Views/ManageAccessoriesView.swift
@@ -1,4 +1,4 @@
-//
+    //
 //  OpenHaystack – Tracking personal Bluetooth devices via Apple's Find My network
 //
 //  Copyright © 2021 Secure Mobile Networking Lab (SEEMOO)
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct ManageAccessoriesView: View {
 
-    @EnvironmentObject var accessoryController: AccessoryController
+    @Environment(\.accessoryController) var accessoryController: AccessoryController
     var accessories: [Accessory] {
         return self.accessoryController.accessories
     }
@@ -39,6 +39,15 @@ struct ManageAccessoriesView: View {
         }
         .toolbar(content: {
             Spacer()
+            
+            Button(action: self.importAccessories, label: {
+                Label("Export accessories", systemImage: "square.and.arrow.down")
+            })
+            
+            Button(action: self.exportAccessories, label: {
+                Label("Export accessories", systemImage: "square.and.arrow.up")
+            })
+            
             Button(action: self.addAccessory) {
                 Label("Add accessory", systemImage: "plus")
             }
@@ -96,6 +105,22 @@ struct ManageAccessoriesView: View {
             _ = try self.accessoryController.addAccessory()
         } catch {
             self.alertType = .keyError
+        }
+    }
+    
+    func exportAccessories() {
+        do {
+            _ = try self.accessoryController.export(accessories: self.accessories)
+        }catch {
+            //TODO: Show alert
+        }
+    }
+    
+    func importAccessories() {
+        do {
+            try self.accessoryController.importAccessories()
+        }catch {
+            //TODO: Show alert
         }
     }
 

--- a/OpenHaystack/OpenHaystack/HaystackApp/Views/ManageAccessoriesView.swift
+++ b/OpenHaystack/OpenHaystack/HaystackApp/Views/ManageAccessoriesView.swift
@@ -125,7 +125,7 @@ struct ManageAccessoriesView: View {
         do {
             _ = try self.accessoryController.export(accessories: self.accessories)
         }catch {
-            //TODO: Show alert
+            self.alertType = .exportFailed
         }
     }
     
@@ -133,7 +133,13 @@ struct ManageAccessoriesView: View {
         do {
             try self.accessoryController.importAccessories()
         }catch {
-            //TODO: Show alert
+            if let importError = error as? AccessoryController.ImportError,
+               importError == .cancelled {
+                //User cancelled the import. No error
+                return
+            }
+            
+            self.alertType = .importFailed
         }
     }
 

--- a/OpenHaystack/OpenHaystack/HaystackApp/Views/OpenHaystackMainView.swift
+++ b/OpenHaystack/OpenHaystack/HaystackApp/Views/OpenHaystackMainView.swift
@@ -365,6 +365,16 @@ struct OpenHaystackMainView: View {
             return Alert(title: Text("Downloading locations failed"),
                          message: Text("We could not download any locations from Apple. Please try again later"),
                          dismissButton: Alert.Button.okay())
+        case .exportFailed:
+            return Alert(
+                title: Text("Export failed"),
+                message: Text("Please check that no the folder is writable and that you have the most current version of the app"),
+                dismissButton: .okay())
+        case .importFailed:
+            return Alert(
+                title: Text("Import failed"),
+                message: Text("Could not import the selected file. Please make sure it has not been modified and that you have the current version of the app."),
+                dismissButton: .okay())
         }
     }
 
@@ -383,6 +393,8 @@ struct OpenHaystackMainView: View {
         case activatePlugin
         case pluginInstallFailed
         case selectDepoyTarget
+        case exportFailed
+        case importFailed
     }
 
 }

--- a/OpenHaystack/OpenHaystack/OpenHaystackApp.swift
+++ b/OpenHaystack/OpenHaystack/OpenHaystackApp.swift
@@ -11,29 +11,45 @@ import SwiftUI
 
 @main
 struct OpenHaystackApp: App {
-    @StateObject var accessoryController: AccessoryController
-    @StateObject var findMyController: FindMyController
+    @Environment(\.accessoryController) var accessoryController: AccessoryController
+    @Environment(\.findMyController) var findMyController: FindMyController
 
-    init() {
-        var accessoryController: AccessoryController
-        if ProcessInfo().arguments.contains("-preview") {
-            accessoryController = AccessoryControllerPreview(accessories: PreviewData.accessories)
-        } else {
-            accessoryController = AccessoryController()
-        }
-        self._accessoryController = StateObject(wrappedValue: accessoryController)
-        self._findMyController = StateObject(wrappedValue: FindMyController(accessories: accessoryController))
-    }
+    init() {}
 
     var body: some Scene {
         WindowGroup {
             OpenHaystackMainView()
-                .environmentObject(accessoryController)
-                .environmentObject(findMyController)
         }
         .commands {
             SidebarCommands()
         }
+        
     }
 
+}
+
+//MARK: Environment objects 
+private struct FindMyControllerEnvironmentKey: EnvironmentKey {
+    static let defaultValue: FindMyController = FindMyController()
+}
+
+private struct AccessoryControllerEnvironmentKey: EnvironmentKey {
+    static let defaultValue: AccessoryController = {
+        if ProcessInfo().arguments.contains("-preview") {
+            return AccessoryControllerPreview(accessories: PreviewData.accessories)
+        } else {
+            return AccessoryController()
+        }
+    }()
+}
+
+extension EnvironmentValues {
+    var findMyController: FindMyController {
+        get {self[FindMyControllerEnvironmentKey]}
+    }
+    
+    var accessoryController: AccessoryController {
+        get{self[AccessoryControllerEnvironmentKey]}
+        set{self[AccessoryControllerEnvironmentKey] = newValue}
+    }
 }

--- a/OpenHaystack/OpenHaystack/OpenHaystackApp.swift
+++ b/OpenHaystack/OpenHaystack/OpenHaystackApp.swift
@@ -11,14 +11,22 @@ import SwiftUI
 
 @main
 struct OpenHaystackApp: App {
-    @Environment(\.accessoryController) var accessoryController: AccessoryController
-    @Environment(\.findMyController) var findMyController: FindMyController
+    @StateObject var accessoryController: AccessoryController
 
-    init() {}
+    init() {
+        let accessoryController: AccessoryController
+        if ProcessInfo().arguments.contains("-preview") {
+            accessoryController = AccessoryControllerPreview(accessories: PreviewData.accessories, findMyController: FindMyController())
+        } else {
+            accessoryController = AccessoryController()
+        }
+        self._accessoryController = StateObject(wrappedValue: accessoryController)
+    }
 
     var body: some Scene {
         WindowGroup {
             OpenHaystackMainView()
+                .environmentObject(self.accessoryController)
         }
         .commands {
             SidebarCommands()
@@ -36,20 +44,9 @@ private struct FindMyControllerEnvironmentKey: EnvironmentKey {
 private struct AccessoryControllerEnvironmentKey: EnvironmentKey {
     static let defaultValue: AccessoryController = {
         if ProcessInfo().arguments.contains("-preview") {
-            return AccessoryControllerPreview(accessories: PreviewData.accessories)
+            return AccessoryControllerPreview(accessories: PreviewData.accessories, findMyController: FindMyController())
         } else {
             return AccessoryController()
         }
     }()
-}
-
-extension EnvironmentValues {
-    var findMyController: FindMyController {
-        get {self[FindMyControllerEnvironmentKey]}
-    }
-    
-    var accessoryController: AccessoryController {
-        get{self[AccessoryControllerEnvironmentKey]}
-        set{self[AccessoryControllerEnvironmentKey] = newValue}
-    }
 }

--- a/OpenHaystack/OpenHaystackMail/AppleAccountData.h
+++ b/OpenHaystack/OpenHaystackMail/AppleAccountData.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy) NSLocale *locale;
 @property(nonatomic, copy) NSTimeZone *timeZone;
 
-@property(nonatomic, copy) NSData *searchPartyToken;
+@property(nonatomic, copy) NSData * _Nullable searchPartyToken;
 
 - (instancetype)initWithMachineID:(NSString *)machineID
                   oneTimePassword:(NSString *)oneTimePassword


### PR DESCRIPTION
These changes introduce 2 new buttons on the left toolbar: 

1. An import button that allows to import accessories from a plist file 
2. An export button that exports all accessories as a plist file. These exports include the private key so other Macs that import them are able to find those devices 

Furthermore, the app now shows if it is able to communicate with the Plug-In in Apple Mail by showing a dot next to the reload-button on the top right 