### PR TITLE
Added a bunch of UUID's into the plist for Mail app version 14

### DIFF
--- a/OpenHaystack/OpenHaystackMail/Info.plist
+++ b/OpenHaystack/OpenHaystackMail/Info.plist
@@ -60,5 +60,65 @@
 	<array>
 		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
 	</array>
+	<key>Supported11.5PluginCompatibilityUUIDs</key>
+	<array>
+		<string># UUIDs for versions from 10.13 to 99.99.99</string>
+		<string># For mail version 11.0 (3441.0.1) on OS X Version 10.13 (build 17A315i)</string>
+		<string>C86CD990-4660-4E36-8CDA-7454DEB2E199</string>
+		<string># For mail version 12.0 (3445.100.39) on OS X Version 10.14.1 (build 18B45d)</string>
+		<string>A4343FAF-AE18-40D0-8A16-DFAE481AF9C1</string>
+		<string># For mail version 13.0 (3608.60.0.2.1) on OS X Version 10.15 (build 19D49f)</string>
+		<string>6EEA38FB-1A0B-469B-BB35-4C2E0EEA9053</string>
+		<string># For mail version 14.0 (3652.0.5.2.1) on OS X Version 11.0 (build 20A5343i)</string>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
+	<key>Supported11.7PluginCompatibilityUUIDs</key>
+	<array>
+		<string># UUIDs for versions from 10.13 to 99.99.99</string>
+		<string># For mail version 11.0 (3441.0.1) on OS X Version 10.13 (build 17A315i)</string>
+		<string>C86CD990-4660-4E36-8CDA-7454DEB2E199</string>
+		<string># For mail version 12.0 (3445.100.39) on OS X Version 10.14.1 (build 18B45d)</string>
+		<string>A4343FAF-AE18-40D0-8A16-DFAE481AF9C1</string>
+		<string># For mail version 13.0 (3608.60.0.2.1) on OS X Version 10.15 (build 19D49f)</string>
+		<string>6EEA38FB-1A0B-469B-BB35-4C2E0EEA9053</string>
+		<string># For mail version 14.0 (3652.0.5.2.1) on OS X Version 11.0 (build 20A5343i)</string>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
+	<key>Supported10.14PluginCompatibilityUUIDs</key>
+	<array>
+		<string># UUIDs for versions from 10.13 to 99.99.99</string>
+		<string># For mail version 11.0 (3441.0.1) on OS X Version 10.13 (build 17A315i)</string>
+		<string>C86CD990-4660-4E36-8CDA-7454DEB2E199</string>
+		<string># For mail version 12.0 (3445.100.39) on OS X Version 10.14.1 (build 18B45d)</string>
+		<string>A4343FAF-AE18-40D0-8A16-DFAE481AF9C1</string>
+		<string># For mail version 13.0 (3608.60.0.2.1) on OS X Version 10.15 (build 19D49f)</string>
+		<string>6EEA38FB-1A0B-469B-BB35-4C2E0EEA9053</string>
+		<string># For mail version 14.0 (3652.0.5.2.1) on OS X Version 11.0 (build 20A5343i)</string>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
+	<key>Supported10.13PluginCompatibilityUUIDs</key>
+	<array>
+		<string># UUIDs for versions from 10.13 to 99.99.99</string>
+		<string># For mail version 11.0 (3441.0.1) on OS X Version 10.13 (build 17A315i)</string>
+		<string>C86CD990-4660-4E36-8CDA-7454DEB2E199</string>
+		<string># For mail version 12.0 (3445.100.39) on OS X Version 10.14.1 (build 18B45d)</string>
+		<string>A4343FAF-AE18-40D0-8A16-DFAE481AF9C1</string>
+		<string># For mail version 13.0 (3608.60.0.2.1) on OS X Version 10.15 (build 19D49f)</string>
+		<string>6EEA38FB-1A0B-469B-BB35-4C2E0EEA9053</string>
+		<string># For mail version 14.0 (3652.0.5.2.1) on OS X Version 11.0 (build 20A5343i)</string>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
+	<key>Supported11.8PluginCompatibilityUUIDs</key>
+	<array>
+		<string># UUIDs for versions from 10.13 to 99.99.99</string>
+		<string># For mail version 11.0 (3441.0.1) on OS X Version 10.13 (build 17A315i)</string>
+		<string>C86CD990-4660-4E36-8CDA-7454DEB2E199</string>
+		<string># For mail version 12.0 (3445.100.39) on OS X Version 10.14.1 (build 18B45d)</string>
+		<string>A4343FAF-AE18-40D0-8A16-DFAE481AF9C1</string>
+		<string># For mail version 13.0 (3608.60.0.2.1) on OS X Version 10.15 (build 19D49f)</string>
+		<string>6EEA38FB-1A0B-469B-BB35-4C2E0EEA9053</string>
+		<string># For mail version 14.0 (3652.0.5.2.1) on OS X Version 11.0 (build 20A5343i)</string>
+		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Source latest Mailbutler plist.
Tested on Big Sur v11.5 Beta (20G5023d); Mail app Version 14.0 (3654.100.0.2.22)