### PR TITLE
Clarify the purpose of the key parameter used by flash_esp32.sh

### DIFF
--- a/Firmware/ESP32/README.md
+++ b/Firmware/ESP32/README.md
@@ -36,7 +36,7 @@ These files are required for the next step: Deploy the firmware.
 Use the `flash_esp32.sh` script to deploy the firmware and a public key to an ESP32 device connected to your local machine:
 
 ```bash
-./flash_esp32.sh -p /dev/yourSerialPort "public-key-in-base64"
+./flash_esp32.sh -p /dev/yourSerialPort "Base64-encoded advertisement key"
 ```
 
 > **Note:** You might need to reset your device after running the script before it starts sending advertisements.


### PR DESCRIPTION
The OpenHaystack UI does not expose the concept of "public key". The script `flash_esp.32` is in fact expecting the base-64 encoded advertisement key.