### PR TITLE
Changes to HCI.py to support TI WL1837 module

### DIFF
--- a/Firmware/Linux_HCI/README.md
+++ b/Firmware/Linux_HCI/README.md
@@ -17,3 +17,27 @@ Our Python script uses HCI calls to configure Bluetooth advertising. You can cop
 ```bash
 sudo python3 HCI.py --key <ADVERTISMENT_KEY>
 ```
+
+### Optional Arguments
+```bash
+sudo python3 HCI.py --key <ADVERTISMENT_KEY> \
+[--no_mac_address_reverse | -nmacr] \
+[--mac_opcode_group_field <MAC_OPCODE_GROUP_FIELD> | -mac_ogf <MAC_OPCODE_GROUP_FIELD>] \
+[--mac_opcode_command_field <MAC_OPCODE_COMMAND_FIELD> | -mac_ocf MAC_OPCODE_COMMAND_FIELD] \
+[--no_restart_bluetooth | -nrbt]
+```
+
+Where
+
+| Option                                                 | Description                                                  |
+|--------------------------------------------------------|--------------------------------------------------------------|
+|`--no_mac_address_reverse`                              | Do not reverse the mac address bytes                         |
+|`--mac_opcode_group_field <MAC_OPCODE_GROUP_FIELD>`     | Vendor-specific OpCode Group Field for setting mac address   |
+|`--mac_opcode_command_field <MAC_OPCODE_COMMAND_FIELD>` | Vendor-specific OpCode Command Field for setting mac address |
+|`--no_restart_bluetooth`                                | Do not restart bluetooth                                     |
+
+Example usage for Texas Instruments WL1838MOD Wi-Fi, Bluetooth, and Bluetooth Smart Module
+
+```bash
+sudo python3 HCI.py --key <ADVERTISMENT_KEY> -nmacr -mac_ocf 0x006
+```


### PR DESCRIPTION
The [TI WL1837](https://www.ti.com/product/WL1837MOD) Wi-Fi & Bluetooth module does not require the mac address bytes to be reversed when setting them, and the OpCode Command Field for setting the mac address is 0x006, not 0x001 (reference [here](https://e2e.ti.com/support/wireless-connectivity/wi-fi-group/wifi/f/wi-fi-forum/551580/set-custom-bt-mac-address-for-wl18xx)). While making options for adding the ability to change the OpCode Group Field and control whether to restart the bluetooth daemon.

Running the HCI.py script as before with `sudo python3 HCI.py --key <ADVERTISMENT_KEY>` behaves the same as it does in main when the new options are not specified.  I've updated the README.md to reflect these changes.

Successful location of my device with your app:
<img width="1312" alt="Screen Shot 2022-01-09 at 2 20 43 PM" src="https://user-images.githubusercontent.com/84455579/149443278-b3420c34-f6ba-4366-a3b9-cc5db5e5d605.png">