### PR TITLE
OpenHaystackMail: add support for Mail.app version 16.0 (macOS 12.3)

### DIFF
--- a/OpenHaystack/OpenHaystackMail/Info.plist
+++ b/OpenHaystack/OpenHaystackMail/Info.plist
@@ -128,6 +128,8 @@
 		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
 		<string>224E7F96-2099-499C-A501-63FB68C79CD2</string>
 		<string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
+		<string># For Mail.app version 16.0 (3696.80.82.1.1) on macOS version 12.3.1 (build 21E258)</string>
+		<string>A4B49485-0377-4FAB-8D8E-E3B8018CFC21</string>
 	</array>
 	<key>Supported12.4PluginCompatibilityUUIDs</key>
 	<array>
@@ -135,6 +137,7 @@
 		<string>224E7F96-2099-499C-A501-63FB68C79CD2</string>
 		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
 		<string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
+		<string>A4B49485-0377-4FAB-8D8E-E3B8018CFC21</string>
 	</array>
 	<key>Supported12.5PluginCompatibilityUUIDs</key>
 	<array>
@@ -142,6 +145,7 @@
 		<string>224E7F96-2099-499C-A501-63FB68C79CD2</string>
 		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
 		<string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
+		<string>A4B49485-0377-4FAB-8D8E-E3B8018CFC21</string>
 	</array>
 	<key>Supported12.6PluginCompatibilityUUIDs</key>
 	<array>
@@ -149,6 +153,7 @@
 		<string>224E7F96-2099-499C-A501-63FB68C79CD2</string>
 		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
 		<string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
+		<string>A4B49485-0377-4FAB-8D8E-E3B8018CFC21</string>
 	</array>
 	<key>Supported12.7PluginCompatibilityUUIDs</key>
 	<array>
@@ -156,6 +161,7 @@
 		<string>224E7F96-2099-499C-A501-63FB68C79CD2</string>
 		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
 		<string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
+		<string>A4B49485-0377-4FAB-8D8E-E3B8018CFC21</string>
 	</array>
 	<key>Supported12.8PluginCompatibilityUUIDs</key>
 	<array>
@@ -163,12 +169,14 @@
 		<string>D985F0E4-3BBC-4B95-BBA1-12056AC4A531</string>
 		<string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
 		<string>224E7F96-2099-499C-A501-63FB68C79CD2</string>
+		<string>A4B49485-0377-4FAB-8D8E-E3B8018CFC21</string>
 	</array>
 	<key>Supported12.9PluginCompatibilityUUIDs</key>
 	<array>
 		<string>25288CEF-7D9B-49A8-BE6B-E41DA6277CF3</string>
 		<string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
 		<string>224E7F96-2099-499C-A501-63FB68C79CD2</string>
+		<string>A4B49485-0377-4FAB-8D8E-E3B8018CFC21</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This updates the mail bundle's `Info.plist` with the expected Mail.app plugin compatibility UUID for Mail version 16.0 for macOS 12.3 and later.

Hopefully this should fix #109.  I'm not sure if this will require updated code signatures somewhere as well but to get things running locally, I used the following script: https://gist.github.com/noahwilliamsson/08500bb6417015b7d6023e0b42cac34e