### PR TITLE
Various fixes on mobile app

### DIFF
--- a/openhaystack-mobile/lib/accessory/accessory_list.dart
+++ b/openhaystack-mobile/lib/accessory/accessory_list.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
@@ -63,12 +64,16 @@ class _AccessoryListState extends State<AccessoryList> {
           return const NoAccessoriesPlaceholder();
         }
 
-        // TODO: Refresh Indicator for desktop
-        // Use pull to refresh method
         return SlidableAutoCloseBehavior(child:
           RefreshIndicator(
             onRefresh: widget.loadLocationUpdates,
-            child: Scrollbar(
+            child: ScrollConfiguration(
+              behavior: ScrollConfiguration.of(context).copyWith(
+                dragDevices: {
+                  PointerDeviceKind.touch,
+                  PointerDeviceKind.mouse,
+                },
+              ),
               child: ListView(
                 children: accessories.map((accessory) {
                   // Calculate distance from users devices location

--- a/openhaystack-mobile/lib/dashboard/dashboard_desktop.dart
+++ b/openhaystack-mobile/lib/dashboard/dashboard_desktop.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:provider/provider.dart';
 import 'package:openhaystack_mobile/accessory/accessory_list.dart';
 import 'package:openhaystack_mobile/accessory/accessory_registry.dart';
@@ -6,6 +7,7 @@ import 'package:openhaystack_mobile/location/location_model.dart';
 import 'package:openhaystack_mobile/map/map.dart';
 import 'package:openhaystack_mobile/preferences/preferences_page.dart';
 import 'package:openhaystack_mobile/preferences/user_preferences_model.dart';
+import 'package:latlong2/latlong.dart';
 
 class DashboardDesktop extends StatefulWidget {
 
@@ -20,7 +22,13 @@ class DashboardDesktop extends StatefulWidget {
 }
 
 class _DashboardDesktopState extends State<DashboardDesktop> {
+  final MapController _mapController = MapController();
 
+  void _centerPoint(LatLng point) {
+    _mapController.fitBounds(
+      LatLngBounds(point),
+    );
+  }
   @override
   void initState() {
     super.initState();
@@ -77,13 +85,16 @@ class _DashboardDesktopState extends State<DashboardDesktop> {
                 Expanded(
                   child: AccessoryList(
                     loadLocationUpdates: loadLocationUpdates,
+                    centerOnPoint: _centerPoint,
                   ),
                 ),
               ],
             ),
           ),
-          const Expanded(
-            child: AccessoryMap(),
+          Expanded(
+            child: AccessoryMap(
+              mapController: _mapController,
+            ),
           ),
         ],
       ),

--- a/openhaystack-mobile/lib/map/map.dart
+++ b/openhaystack-mobile/lib/map/map.dart
@@ -71,11 +71,14 @@ class _AccessoryMapState extends State<AccessoryMap> {
       .where((accessory) => accessory.lastLocation != null)
       .map((accessory) => accessory.lastLocation!)
       .toList();
-    _mapController.fitBounds(
-      LatLngBounds.fromPoints([...points, ...accessoryPoints]),
-      options: const FitBoundsOptions(
-        padding: EdgeInsets.all(25),
-      ));
+    points = [... points, ...accessoryPoints];
+    if (points.isNotEmpty) {
+      _mapController.fitBounds(
+          LatLngBounds.fromPoints(points),
+          options: const FitBoundsOptions(
+            padding: EdgeInsets.all(25),
+          ));
+    }
   }
 
   @override

--- a/openhaystack-mobile/pubspec.lock
+++ b/openhaystack-mobile/pubspec.lock
@@ -421,7 +421,7 @@ packages:
       name: pointycastle
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.1"
+    version: "3.6.1"
   positioned_tap_detector_2:
     dependency: transitive
     description:

--- a/openhaystack-mobile/pubspec.yaml
+++ b/openhaystack-mobile/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
 
   # Cryptography
   # latest version of pointy castle for crypto functions
-  pointycastle: ^3.4.0
+  pointycastle: ^3.6.1
 
   # State Management
   provider: ^6.0.1


### PR DESCRIPTION
This pull request contains several fixes to the mobile-app To make it work smoothly in windows.


1. Fix refresh indicator
2. Fix "click on accessory" -> center map
3. fix fitBounds when no data available (causes error first run)
4. update deps (Attempt to make this working in web.)

The location gathering is not working. cause the [location package](https://pub.dev/packages/location) is not supporting windows. We could switch to [geolocator](https://pub.dev/packages/geolocator) but i dont see it as a main issue to not have a location fix on my desktop machine.