### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Feel free to port OpenHaystack to other devices that support Bluetooth Low Energ
 | Platform | Tested on | Deploy via app | Comment |
 |----------|-----------|:--------------:|---------|
 | [Nordic nRF51](Firmware/Microbit_v1) | BBC micro:bit v1 | ✓ | Only supports nRF51822 at this time (see issue #6). |
-| [Espressif ESP32](Firmware/ESP32) | SP32-WROOM, ESP32-WROVER | ✓ | Deployment can take up to 3 minutes. Requires Python 3. Thanks **@fhessel**. |
+| [Espressif ESP32](Firmware/ESP32) | ESP32-WROOM, ESP32-WROVER | ✓ | Deployment can take up to 3 minutes. Requires Python 3. Thanks **@fhessel**. |
 | [Linux HCI](Firmware/Linux_HCI) | Raspberry Pi 4 w/ Raspbian | | Should support any Linux machine. |
 
 ![Setup](Resources/Setup.jpg)


### PR DESCRIPTION
Changes `SP32-WROOM` to `ESP32-WROOM`.

Thanks for all of your work on this project!