### PR TITLE
Correctly handle versions with extension

### DIFF
--- a/OpenHaystack/OpenHaystack/HaystackApp/UpdateCheckController.swift
+++ b/OpenHaystack/OpenHaystack/HaystackApp/UpdateCheckController.swift
@@ -90,8 +90,19 @@ public struct UpdateCheckController {
     ///   - installedVersion: The currently installed version
     /// - Returns: .older when a newer version is available. .newer when the installed version is newer .same, if both versions are equal
     internal static func compareVersions(availableVersion: String, installedVersion: String) -> VersionCompare {
-        let availableVersionSplit = availableVersion.split(separator: ".")
-        let installedVersionSplit = installedVersion.split(separator: ".")
+        // Handle dash extensions
+        var availableVersionTrim = availableVersion
+        var installedVersionTrim = installedVersion
+
+        if let dashIndex = availablePart.firstIndex(of: "-") {
+            availablePart = availablePart[..<dashIndex]
+        }
+        if let dashIndex = installedPart.firstIndex(of: "-") {
+            installedPart = installedPart[..<dashIndex]
+        }
+
+        let availableVersionSplit = availableVersionTrim.split(separator: ".")
+        let installedVersionSplit = installedVersionTrim.split(separator: ".")
 
         for (idx, availableVersionPart) in availableVersionSplit.enumerated() {
 


### PR DESCRIPTION
This PR fixes version resolving when the version has an extension with a dash in the end, for example `0.5.2-local`.
This allows local builds to not get constant prompts for downloading the new version, even though the base part of the version is the same.