### PR TITLE
OpenHaystackMail: Add support for Mail.app on Ventura 13.5

### DIFF
--- a/OpenHaystack/OpenHaystackMail/Info.plist
+++ b/OpenHaystack/OpenHaystackMail/Info.plist
@@ -221,5 +221,14 @@
 		<string>A4B49485-0377-4FAB-8D8E-E3B8018CFC21</string>
 		<string>281F8A5C-0AF9-4BE6-8B8A-C0CB9C2068BE</string>
 	</array>
+	<key>Supported13.5PluginCompatibilityUUIDs</key>
+	<array>
+		<string>25288CEF-7D9B-49A8-BE6B-E41DA6277CF3</string>
+		<string>6FF8B077-81FA-45A4-BD57-17CDE79F13A5</string>
+		<string>224E7F96-2099-499C-A501-63FB68C79CD2</string>
+		<string>890E3F5B-9490-4828-8F3F-B6561E513FCC</string>
+		<string>A4B49485-0377-4FAB-8D8E-E3B8018CFC21</string>
+		<string>281F8A5C-0AF9-4BE6-8B8A-C0CB9C2068BE</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request adds support for Mail.app on macOS Ventura 13.5.

Before this PR: The plugin bundle fails to load in Mail.app on Ventura 13.5.

After this PR:

![Screenshot_2023-08-03_23-12-34](https://github.com/seemoo-lab/openhaystack/assets/79528/9d838cfb-71ea-412d-89d3-0b3f62eec635)

![Screenshot_2023-08-03_23-21-47](https://github.com/seemoo-lab/openhaystack/assets/79528/c645890d-755f-4eea-bae6-fd425f739798)