### PR TITLE
[fix] Derive symmetric key correctly

### DIFF
--- a/OpenHaystack/OpenHaystack/HaystackApp/Model/Accessory.swift
+++ b/OpenHaystack/OpenHaystack/HaystackApp/Model/Accessory.swift
@@ -214,7 +214,7 @@ class Accessory: ObservableObject, Codable, Identifiable, Equatable, Hashable {
             /// Derive FindMyKeys until we have symmetric key from one week before now
             while self.lastDerivationTimestamp < Date() - TimeInterval(7 * 24 * 60 * 60) {
                 self.lastDerivationTimestamp.addTimeInterval(self.updateInterval)
-                self.oldestRelevantSymmetricKey = Accessory.kdf(inputData: self.symmetricKey, sharedInfo: "update".data(using: .ascii)!, bytesToReturn: 32)
+                self.oldestRelevantSymmetricKey = Accessory.kdf(inputData: self.oldestRelevantSymmetricKey, sharedInfo: "update".data(using: .ascii)!, bytesToReturn: 32)
             }
 
             /// we need to generate Keys from seven days in the past until now and 10 extra keys in case of desynchronization


### PR DESCRIPTION
I discussed this with @Sn0wfreezeDev privately, 

When deriving symmetric keys, the code was always deriving from the root symmetric key instead of deriving from the oldest relevant symmetric key.

This produced the same symmetric key over and over and over instead of deriving new rolling ones. 

Thanks to @ThatFatPat for helping me debug this 🚀 