### PR TITLE
Address report decryption failure

### DIFF
--- a/OpenHaystack/OpenHaystack/FindMy/FindMyController.swift
+++ b/OpenHaystack/OpenHaystack/FindMy/FindMyController.swift
@@ -205,6 +205,7 @@ class FindMyController: ObservableObject {
 
             let accessQueue = DispatchQueue(label: "threadSafeAccess", qos: .userInitiated, attributes: .concurrent, autoreleaseFrequency: .workItem, target: nil)
             var decryptedReports = [FindMyLocationReport](repeating: FindMyLocationReport(lat: 0, lng: 0, acc: 0, dP: Date(), t: Date(), c: 0), count: reports.count)
+            var failedDecryptIndexes = [Int]()
             DispatchQueue.concurrentPerform(iterations: reports.count) { (reportIdx) in
                 let report = reports[reportIdx]
                 guard let key = keyMap[report.id] else { return }
@@ -215,11 +216,16 @@ class FindMyController: ObservableObject {
                         decryptedReports[reportIdx] = locationReport
                     }
                 } catch {
-                    return
+                    accessQueue.async(flags: .barrier) {
+                        failedDecryptIndexes.append(reportIdx)
+                    }
                 }
             }
 
             accessQueue.sync {
+                for index in failedDecryptIndexes.sorted(by: { $0 > $1 }) {
+                    decryptedReports.remove(at: index)
+                }
                 devices[deviceIdx].decryptedReports = decryptedReports
             }
         }


### PR DESCRIPTION
Noticed that on some instances a single report from the results payload might fail to decrypt for reasons I'm not sure why, that is not handled by `FindMyController` which meant that a failing report would actually show as a random location at the Atlantic Ocean (lat 0, long 0).

This PR changes that, so the controller keeps track of whatever indexes failed to be decrypted and remove them from the array of results.